### PR TITLE
Add mock Trident Network explorer

### DIFF
--- a/trident-network-explorer/.gitignore
+++ b/trident-network-explorer/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+frontend/node_modules
+backend/node_modules
+build
+.env

--- a/trident-network-explorer/README.md
+++ b/trident-network-explorer/README.md
@@ -1,0 +1,23 @@
+# Trident Network Explorer
+
+This is a mock blockchain explorer and wallet UI for the Trident Network (TRI). It includes a simple Express backend serving fake blockchain data and a React frontend that displays it.
+
+## Requirements
+
+- Docker and Docker Compose
+
+## Running with Docker Compose
+
+```bash
+cd trident-network-explorer
+docker-compose up --build
+```
+
+The backend will be available at `http://localhost:4000` and the frontend at `http://localhost:3000`.
+
+## Project Structure
+
+- `backend` - Node.js Express API server
+- `frontend` - React application
+
+Both services are configured for demonstration only and do not connect to a real blockchain.

--- a/trident-network-explorer/backend/Dockerfile
+++ b/trident-network-explorer/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --production || npm install --production --force
+COPY . .
+EXPOSE 4000
+CMD ["npm", "start"]

--- a/trident-network-explorer/backend/package.json
+++ b/trident-network-explorer/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "trident-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/trident-network-explorer/backend/public/index.html
+++ b/trident-network-explorer/backend/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Trident Network Explorer</title>
+</head>
+<body>
+  <h1>Trident Network Explorer</h1>
+  <p>Backend is running.</p>
+</body>
+</html>

--- a/trident-network-explorer/backend/server.js
+++ b/trident-network-explorer/backend/server.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const cors = require('cors');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 4000;
+
+app.use(cors());
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+// mock data
+const latestBlock = {
+  number: 123456,
+  hash: '0xabcdef1234567890',
+  timestamp: new Date().toISOString(),
+  validator: 'TVALIDATORADDRESS'
+};
+
+const accounts = {
+  'TADDRESS1': {
+    balance: 1000,
+    transactions: [
+      { txid: '0x1', amount: 100, type: 'send', timestamp: new Date().toISOString() },
+      { txid: '0x2', amount: 50, type: 'receive', timestamp: new Date().toISOString() }
+    ]
+  }
+};
+
+const validators = [
+  { address: 'TVALIDATOR1', power: 1000, status: 'active' },
+  { address: 'TVALIDATOR2', power: 900, status: 'active' },
+  { address: 'TVALIDATOR3', power: 500, status: 'inactive' }
+];
+
+// routes
+app.get('/api/v1/blocks/latest', (req, res) => {
+  res.json(latestBlock);
+});
+
+app.get('/api/v1/accounts/:address', (req, res) => {
+  const addr = req.params.address;
+  const data = accounts[addr] || { balance: 0, transactions: [] };
+  res.json(data);
+});
+
+app.get('/api/v1/validators', (req, res) => {
+  res.json(validators);
+});
+
+app.listen(PORT, () => {
+  console.log(`Trident Network mock API server running on port ${PORT}`);
+});

--- a/trident-network-explorer/docker-compose.yml
+++ b/trident-network-explorer/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "4000:4000"
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:80"
+    environment:
+      - REACT_APP_API_URL=http://localhost:4000
+    depends_on:
+      - backend

--- a/trident-network-explorer/frontend/Dockerfile
+++ b/trident-network-explorer/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/trident-network-explorer/frontend/package.json
+++ b/trident-network-explorer/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "trident-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/trident-network-explorer/frontend/public/index.html
+++ b/trident-network-explorer/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Trident Network Explorer</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="../src/index.js" type="module"></script>
+</body>
+</html>

--- a/trident-network-explorer/frontend/public/trident-logo.svg
+++ b/trident-network-explorer/frontend/public/trident-logo.svg
@@ -1,0 +1,3 @@
+<svg width="120" height="120" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="60,10 90,110 60,90 30,110" fill="#001f3f" />
+</svg>

--- a/trident-network-explorer/frontend/src/App.js
+++ b/trident-network-explorer/frontend/src/App.js
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from 'react';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
+
+function LatestBlock() {
+  const [block, setBlock] = useState(null);
+  useEffect(() => {
+    fetch(`${API_URL}/api/v1/blocks/latest`)
+      .then(res => res.json())
+      .then(setBlock);
+  }, []);
+  if (!block) return <p>Loading latest block...</p>;
+  return (
+    <div>
+      <h2>Latest Block</h2>
+      <p>Number: {block.number}</p>
+      <p>Hash: {block.hash}</p>
+      <p>Validator: {block.validator}</p>
+      <p>Timestamp: {block.timestamp}</p>
+    </div>
+  );
+}
+
+function AccountLookup() {
+  const [address, setAddress] = useState('');
+  const [account, setAccount] = useState(null);
+  const lookup = () => {
+    fetch(`${API_URL}/api/v1/accounts/${address}`)
+      .then(res => res.json())
+      .then(setAccount);
+  };
+  return (
+    <div>
+      <h2>Account Lookup</h2>
+      <input value={address} onChange={e => setAddress(e.target.value)} placeholder="Address" />
+      <button onClick={lookup}>Lookup</button>
+      {account && (
+        <div>
+          <p>Balance: {account.balance} TRI</p>
+          <h4>Transactions</h4>
+          <ul>
+            {account.transactions.map(tx => (
+              <li key={tx.txid}>{tx.txid} - {tx.type} {tx.amount} TRI at {tx.timestamp}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ValidatorList() {
+  const [vals, setVals] = useState([]);
+  useEffect(() => {
+    fetch(`${API_URL}/api/v1/validators`)
+      .then(res => res.json())
+      .then(setVals);
+  }, []);
+  return (
+    <div>
+      <h2>Validators</h2>
+      <ul>
+        {vals.map(v => (
+          <li key={v.address}>{v.address} - power {v.power} - {v.status}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <div style={{ padding: '1rem', fontFamily: 'Arial', backgroundColor: '#001f3f', color: 'white', minHeight: '100vh' }}>
+      <h1>Trident Network Explorer</h1>
+      <LatestBlock />
+      <AccountLookup />
+      <ValidatorList />
+    </div>
+  );
+}
+
+export default App;

--- a/trident-network-explorer/frontend/src/index.js
+++ b/trident-network-explorer/frontend/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- add `trident-network-explorer` folder with backend and frontend projects
- backend is an Express server providing mock API endpoints
- frontend is a small React app displaying mock blockchain data
- docker-compose configuration to run both services together
- documentation for running the explorer

## Testing
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68777f6519988328acc82d032fc4a88f