### PR TITLE
Add mock wallet interface

### DIFF
--- a/trident-network-explorer/README.md
+++ b/trident-network-explorer/README.md
@@ -54,3 +54,16 @@ REACT_APP_API_URL=http://localhost:4000
 ```
 
 Docker Compose automatically loads these variables when bringing up the services.
+
+## Mock Wallet Usage
+
+Navigate to the **Wallet** page from the navigation bar. Enter any string as a
+private key and click **Login**. The application derives a deterministic mock
+address from the key and stores the key in your browser's local storage. Once
+logged in, the wallet page displays your public address, balance and recent
+transactions by querying `/api/v1/accounts/<address>`.
+
+Use the **Logout** button in the navigation bar or on the wallet page to clear
+the stored credentials. This wallet is implemented entirely on the frontend and
+is intended for demonstration purposes only&mdash;no real cryptographic key
+management or blockchain interaction occurs.

--- a/trident-network-explorer/frontend/src/App.css
+++ b/trident-network-explorer/frontend/src/App.css
@@ -23,6 +23,9 @@ body {
   margin-right: 1rem;
   text-decoration: none;
 }
+.navbar button {
+  margin-left: 0.5rem;
+}
 
 .container {
   padding: 1rem;


### PR DESCRIPTION
## Summary
- integrate mock wallet page in the explorer
- show login status and logout option in the navbar
- derive fake address from private key and store locally
- fetch account balance and txs from existing endpoint
- document wallet usage in the explorer README

## Testing
- `npm run build` within `trident-network-explorer/frontend`
- `node server.js` within `trident-network-explorer/backend`

------
https://chatgpt.com/codex/tasks/task_e_6877878c442c83288e24c7ff49e8ed39