### PR TITLE
Add i18n and dark mode

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,6 +13,8 @@ PORT=3000
 REACT_APP_API_URL=http://localhost:4000
 REACT_APP_APP_TITLE=Trident Explorer
 REACT_APP_THEME_COLOR=#001730
+REACT_APP_DEFAULT_LANGUAGE=en
+REACT_APP_DEFAULT_THEME=dark
 ```
 
 Available variables (defaults shown):
@@ -21,6 +23,20 @@ Available variables (defaults shown):
 - `REACT_APP_API_URL` (`http://localhost:4000`) - backend API base URL.
 - `REACT_APP_APP_TITLE` (`Trident Explorer`) - page title and branding text.
 - `REACT_APP_THEME_COLOR` (`#001730`) - primary theme color.
+- `REACT_APP_DEFAULT_LANGUAGE` (`en`) - initial UI language.
+- `REACT_APP_DEFAULT_THEME` (`dark`) - initial theme mode.
+
+### Multi-language Support
+
+The interface uses `react-i18next` with English and Portuguese translations built-in.
+Use the language selector in the navbar to switch languages. The chosen language
+is saved in local storage.
+
+### Customizing Defaults
+
+Set `REACT_APP_DEFAULT_LANGUAGE` and `REACT_APP_DEFAULT_THEME` in your `.env`
+to change the default language or theme on first load. Users can override these
+values via the navbar controls and their preferences are persisted locally.
 
 ## Development
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,10 @@
       "name": "trident-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "i18next": "^25.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^15.6.0",
         "react-router-dom": "^6.14.1",
         "react-scripts": "5.0.1"
       }
@@ -8811,6 +8813,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-webpack-plugin": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.3.tgz",
@@ -8962,6 +8973,37 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.2.tgz",
+      "integrity": "sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -13749,6 +13791,32 @@
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
     },
+    "node_modules/react-i18next": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.0.tgz",
+      "integrity": "sha512-W135dB0rDfiFmbMipC17nOhGdttO5mzH8BivY+2ybsQBbXvxWIwl3cmeH3T9d+YPBSJu/ouyJKFJTtkK7rJofw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -16451,6 +16519,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-hr-time": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "i18next": "^25.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1",
-    "react-router-dom": "^6.14.1"
+    "react-i18next": "^15.6.0",
+    "react-router-dom": "^6.14.1",
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,12 +1,20 @@
 :root {
   --primary-color: #001730;
+  --background-color: var(--primary-color);
+  --text-color: #fff;
+}
+
+[data-theme='light'] {
+  --primary-color: #f0f0f0;
+  --background-color: #f0f0f0;
+  --text-color: #000;
 }
 
 body {
   margin: 0;
   font-family: Arial, sans-serif;
-  background-color: var(--primary-color);
-  color: white;
+  background-color: var(--background-color);
+  color: var(--text-color);
   min-height: 100vh;
 }
 
@@ -25,10 +33,11 @@ body {
 .navbar .brand {
   font-weight: bold;
   margin-right: 1rem;
+  color: var(--text-color);
 }
 
 .navbar a {
-  color: white;
+  color: var(--text-color);
   margin-right: 1rem;
   text-decoration: none;
 }
@@ -42,7 +51,7 @@ body {
 
 .spinner {
   border: 4px solid rgba(255, 255, 255, 0.3);
-  border-top: 4px solid #fff;
+  border-top: 4px solid var(--text-color);
   border-radius: 50%;
   width: 24px;
   height: 24px;
@@ -55,8 +64,8 @@ body {
   justify-content: center;
   align-items: center;
   height: 100vh;
-  background-color: var(--primary-color);
-  color: white;
+  background-color: var(--background-color);
+  color: var(--text-color);
   font-size: 1.5rem;
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import i18n from 'i18next';
 import './App.css';
+import './i18n';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
@@ -18,6 +21,7 @@ function Spinner() {
 }
 
 function LatestBlock() {
+  const { t } = useTranslation();
   const [block, setBlock] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -39,19 +43,20 @@ function LatestBlock() {
       });
   }, []);
   if (loading) return <Spinner />;
-  if (error) return <p>Service unavailable</p>;
+  if (error) return <p>{t('Service unavailable')}</p>;
   return (
     <div>
-      <h2>Latest Block</h2>
-      <p>Number: {block.number}</p>
-      <p>Hash: {block.hash}</p>
-      <p>Validator: {block.validator}</p>
-      <p>Timestamp: {block.timestamp}</p>
+      <h2>{t('Latest Block')}</h2>
+      <p>{t('Number')}: {block.number}</p>
+      <p>{t('Hash')}: {block.hash}</p>
+      <p>{t('Validator')}: {block.validator}</p>
+      <p>{t('Timestamp')}: {block.timestamp}</p>
     </div>
   );
 }
 
 function BlockHistory() {
+  const { t } = useTranslation();
   const [blocks, setBlocks] = useState([]);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
@@ -77,17 +82,17 @@ function BlockHistory() {
 
   return (
     <div>
-      <h2>Block History</h2>
-      <button onClick={() => setPage(p => Math.max(1, p - 1))}>Previous</button>
-      <button onClick={() => setPage(p => p + 1)} style={{ marginLeft: '0.5rem' }}>Next</button>
+      <h2>{t('Block History')}</h2>
+      <button onClick={() => setPage(p => Math.max(1, p - 1))}>{t('Previous')}</button>
+      <button onClick={() => setPage(p => p + 1)} style={{ marginLeft: '0.5rem' }}>{t('Next')}</button>
       {loading ? (
         <Spinner />
       ) : error ? (
-        <p>Service unavailable</p>
+        <p>{t('Service unavailable')}</p>
       ) : (
         <ul>
           {blocks.map(b => (
-            <li key={b.number}>Block {b.number} - {b.validator} - {b.timestamp}</li>
+            <li key={b.number}>{t('Block')} {b.number} - {b.validator} - {b.timestamp}</li>
           ))}
         </ul>
       )}
@@ -96,6 +101,7 @@ function BlockHistory() {
 }
 
 function AccountLookup() {
+  const { t } = useTranslation();
   const [address, setAddress] = useState('');
   const [account, setAccount] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -120,23 +126,23 @@ function AccountLookup() {
   };
   return (
     <div>
-      <h2>Account Lookup</h2>
-      <input value={address} onChange={e => setAddress(e.target.value)} placeholder="Address" />
-      <button onClick={lookup}>Lookup</button>
+      <h2>{t('Account Lookup')}</h2>
+      <input value={address} onChange={e => setAddress(e.target.value)} placeholder={t('Address')} />
+      <button onClick={lookup}>{t('Lookup')}</button>
       {loading && <Spinner />}
-      {error && !loading && <p>Service unavailable</p>}
+      {error && !loading && <p>{t('Service unavailable')}</p>}
       {account && !loading && !error && (
         <div>
-          <p>Balance: {account.balance} TRI</p>
-          <h4>Transactions</h4>
+          <p>{t('Balance')}: {account.balance} TRI</p>
+          <h4>{t('Transactions')}</h4>
           <table style={{ width: '100%', color: 'white' }}>
             <thead>
               <tr>
-                <th>TxID</th>
-                <th>From</th>
-                <th>To</th>
-                <th>Amount</th>
-                <th>Timestamp</th>
+                <th>{t('TxID')}</th>
+                <th>{t('From')}</th>
+                <th>{t('To')}</th>
+                <th>{t('Amount')}</th>
+                <th>{t('Timestamp')}</th>
               </tr>
             </thead>
             <tbody>
@@ -158,6 +164,7 @@ function AccountLookup() {
 }
 
 function ValidatorList() {
+  const { t } = useTranslation();
   const [vals, setVals] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -180,11 +187,11 @@ function ValidatorList() {
   }, []);
   return (
     <div>
-      <h2>Validators</h2>
+      <h2>{t('Validators')}</h2>
       {loading ? (
         <Spinner />
       ) : error ? (
-        <p>Service unavailable</p>
+        <p>{t('Service unavailable')}</p>
       ) : (
         <ul>
           {vals.map(v => (
@@ -197,6 +204,7 @@ function ValidatorList() {
 }
 
 function WalletPage({ wallet, login, logout }) {
+  const { t } = useTranslation();
   const [privKey, setPrivKey] = useState('');
   const [account, setAccount] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -234,40 +242,40 @@ function WalletPage({ wallet, login, logout }) {
   if (!wallet) {
     return (
       <div className="container">
-        <h2>Wallet Login</h2>
+        <h2>{t('Wallet Login')}</h2>
         <input
           type="password"
           value={privKey}
           onChange={e => setPrivKey(e.target.value)}
-          placeholder="Private Key"
+          placeholder={t('Private Key')}
         />
-        <button onClick={handleLogin}>Login</button>
+        <button onClick={handleLogin}>{t('Login')}</button>
       </div>
     );
   }
 
   return (
     <div className="container">
-      <h2>Wallet</h2>
-      <p>Address: {wallet.address}</p>
-      <button onClick={logout}>Logout</button>
+      <h2>{t('Wallet Page')}</h2>
+      <p>{t('Address')}: {wallet.address}</p>
+      <button onClick={logout}>{t('Logout')}</button>
       {loading ? (
         <Spinner />
       ) : error ? (
-        <p>Service unavailable</p>
+        <p>{t('Service unavailable')}</p>
       ) : (
         account && (
           <div>
-            <p>Balance: {account.balance} TRI</p>
-            <h4>Transactions</h4>
+            <p>{t('Balance')}: {account.balance} TRI</p>
+            <h4>{t('Transactions')}</h4>
             <table style={{ width: '100%', color: 'white' }}>
               <thead>
                 <tr>
-                  <th>TxID</th>
-                  <th>From</th>
-                  <th>To</th>
-                  <th>Amount</th>
-                  <th>Timestamp</th>
+                  <th>{t('TxID')}</th>
+                  <th>{t('From')}</th>
+                  <th>{t('To')}</th>
+                  <th>{t('Amount')}</th>
+                  <th>{t('Timestamp')}</th>
                 </tr>
               </thead>
               <tbody>
@@ -291,20 +299,28 @@ function WalletPage({ wallet, login, logout }) {
 
 const APP_TITLE = process.env.REACT_APP_APP_TITLE || 'Trident Explorer';
 
-function NavBar({ wallet, logout }) {
+function NavBar({ wallet, logout, language, setLanguage, theme, toggleTheme }) {
+  const { t } = useTranslation();
   return (
     <nav className="navbar">
       <img src="/trident-logo.svg" alt={APP_TITLE} />
       <span className="brand">{APP_TITLE}</span>
-      <Link to="/">Latest Block</Link>
-      <Link to="/account">Account Lookup</Link>
-      <Link to="/validators">Validator List</Link>
-      <Link to="/wallet">Wallet</Link>
-      <Link to="/admin">Admin</Link>
+      <Link to="/">{t('Latest Block')}</Link>
+      <Link to="/account">{t('Account Lookup')}</Link>
+      <Link to="/validators">{t('Validator List')}</Link>
+      <Link to="/wallet">{t('Wallet')}</Link>
+      <Link to="/admin">{t('Admin Panel')}</Link>
+      <select value={language} onChange={e => setLanguage(e.target.value)} style={{ marginLeft: 'auto' }}>
+        <option value="en">EN</option>
+        <option value="pt">PT</option>
+      </select>
+      <button onClick={toggleTheme} style={{ marginLeft: '0.5rem' }}>
+        {theme === 'dark' ? t('Light Mode') : t('Dark Mode')}
+      </button>
       {wallet && (
-        <span style={{ marginLeft: 'auto' }}>
-          Logged in as {wallet.address}{' '}
-          <button onClick={logout}>Logout</button>
+        <span style={{ marginLeft: '0.5rem' }}>
+          {wallet.address}{' '}
+          <button onClick={logout}>{t('Logout')}</button>
         </span>
       )}
     </nav>
@@ -321,6 +337,7 @@ function Home() {
 }
 
 function AdminPage() {
+  const { t } = useTranslation();
   const [health, setHealth] = useState(null);
   const [env, setEnv] = useState(null);
   const [error, setError] = useState(false);
@@ -348,17 +365,17 @@ function AdminPage() {
   }, []);
   return (
     <div className="container">
-      <h2>Admin Panel</h2>
+      <h2>{t('Admin Panel')}</h2>
       {!health ? <Spinner /> : error ? (
-        <p>Service unavailable</p>
+        <p>{t('Service unavailable')}</p>
       ) : (
-        <p>Status: {health.status} at {health.timestamp}</p>
+        <p>{t('Status')}: {health.status} {t('Timestamp')}: {health.timestamp}</p>
       )}
       {!env ? <Spinner /> : error ? (
-        <p>Service unavailable</p>
+        <p>{t('Service unavailable')}</p>
       ) : (
         <div>
-          <h3>Environment</h3>
+          <h3>{t('Environment')}</h3>
           <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(env, null, 2)}</pre>
         </div>
       )}
@@ -375,6 +392,26 @@ function App() {
     return null;
   });
 
+  const [theme, setTheme] = useState(() => {
+    return localStorage.getItem('theme') || process.env.REACT_APP_DEFAULT_THEME || 'dark';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const [language, setLanguage] = useState(() => {
+    return localStorage.getItem('language') || process.env.REACT_APP_DEFAULT_LANGUAGE || 'en';
+  });
+
+  useEffect(() => {
+    i18n.changeLanguage(language);
+    localStorage.setItem('language', language);
+  }, [language]);
+
+  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+
   const login = privKey => {
     const addr = deriveAddress(privKey);
     localStorage.setItem('privateKey', privKey);
@@ -388,7 +425,14 @@ function App() {
 
   return (
     <Router>
-      <NavBar wallet={wallet} logout={logout} />
+      <NavBar
+        wallet={wallet}
+        logout={logout}
+        language={language}
+        setLanguage={setLanguage}
+        theme={theme}
+        toggleTheme={toggleTheme}
+      />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/account" element={<div className="container"><AccountLookup /></div>} />

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,0 +1,94 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+const resources = {
+  en: {
+    translation: {
+      "Latest Block": "Latest Block",
+      "Block History": "Block History",
+      "Block": "Block",
+      "Number": "Number",
+      "Hash": "Hash",
+      "Validator": "Validator",
+      "Timestamp": "Timestamp",
+      "Validators": "Validators",
+      "Validator List": "Validator List",
+      "Account Lookup": "Account Lookup",
+      "Previous": "Previous",
+      "Next": "Next",
+      "Service unavailable": "Service unavailable",
+      "Address": "Address",
+      "Lookup": "Lookup",
+      "Balance": "Balance",
+      "Transactions": "Transactions",
+      "TxID": "TxID",
+      "From": "From",
+      "To": "To",
+      "Amount": "Amount",
+      "Wallet Login": "Wallet Login",
+      "Private Key": "Private Key",
+      "Login": "Login",
+      "Wallet": "Wallet",
+      "Logout": "Logout",
+      "Admin Panel": "Admin Panel",
+      "Environment": "Environment",
+      "Status": "Status",
+      "Wallet Page": "Wallet",
+      "Loading": "Loading...",
+      "Dark Mode": "Dark Mode",
+      "Light Mode": "Light Mode"
+    }
+  },
+  pt: {
+    translation: {
+      "Latest Block": "\u00dAltimo Bloco",
+      "Block History": "Hist\u00f3rico de Blocos",
+      "Block": "Bloco",
+      "Number": "N\u00famero",
+      "Hash": "Hash",
+      "Validator": "Validador",
+      "Timestamp": "Data/Hora",
+      "Validators": "Validadores",
+      "Validator List": "Lista de Validadores",
+      "Account Lookup": "Consulta de Conta",
+      "Previous": "Anterior",
+      "Next": "Pr\u00f3ximo",
+      "Service unavailable": "Servi\u00e7o indispon\u00edvel",
+      "Address": "Endere\u00e7o",
+      "Lookup": "Consultar",
+      "Balance": "Saldo",
+      "Transactions": "Transa\u00e7\u00f5es",
+      "TxID": "ID",
+      "From": "De",
+      "To": "Para",
+      "Amount": "Quantia",
+      "Wallet Login": "Login da Carteira",
+      "Private Key": "Chave Privada",
+      "Login": "Entrar",
+      "Wallet": "Carteira",
+      "Logout": "Sair",
+      "Admin Panel": "Painel de Administra\u00e7\u00e3o",
+      "Environment": "Ambiente",
+      "Status": "Status",
+      "Wallet Page": "Carteira",
+      "Loading": "Carregando...",
+      "Dark Mode": "Modo Escuro",
+      "Light Mode": "Modo Claro"
+    }
+  }
+};
+
+const defaultLanguage = localStorage.getItem('language') || process.env.REACT_APP_DEFAULT_LANGUAGE || 'en';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources,
+    lng: defaultLanguage,
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false
+    }
+  });
+
+export default i18n;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,6 +6,8 @@ const title = process.env.REACT_APP_APP_TITLE || 'Trident Explorer';
 document.title = title;
 const theme = process.env.REACT_APP_THEME_COLOR || '#001730';
 document.documentElement.style.setProperty('--primary-color', theme);
+const defaultTheme = localStorage.getItem('theme') || process.env.REACT_APP_DEFAULT_THEME || 'dark';
+document.documentElement.setAttribute('data-theme', defaultTheme);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);


### PR DESCRIPTION
## Summary
- add react-i18next configuration and Portuguese translations
- implement theme and language state with local storage
- add navbar controls for language and dark mode
- update CSS to support light/dark themes
- expose DEFAULT_LANGUAGE and DEFAULT_THEME env vars
- document customization and language support

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68778fe86cb08328a8e732754d531c17