### PR TITLE
Production polish and docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ docker build -t trident-network:latest .
 docker-compose up
 ```
 
+### Run Explorer Locally
+```bash
+# requires Docker
+docker compose -f docker-compose.dev.yml up
+```
+
+This starts the backend on port 4000 and the React frontend on port 3000 using mock data.
+
+### Deploy with Docker Compose
+```bash
+docker compose -f docker-compose.prod.yml up -d
+```
+This uses the Dockerfiles in `frontend/` and `backend/` to build production images.
+
 ## License
 
 MIT License

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,18 @@ Available variables (defaults shown):
 - `TRIDENT_NODE_RPC_URL` (`http://localhost:8090`) - RPC endpoint used when `CHAIN_MODE=rpc`.
 - `FRONTEND_URL` (`http://localhost:3000`) - allowed CORS origin.
 
+## Quickstart
+
+Install dependencies and start the server:
+
+```bash
+cd backend
+npm install
+npm start
+```
+
+The API will be available at `http://localhost:4000`.
+
 ## API Endpoints
 
 | Method | Endpoint | Description |
@@ -33,6 +45,7 @@ Available variables (defaults shown):
 | GET | `/api/v1/transactions/:id` | Transaction details |
 | GET | `/api/v1/accounts/:address` | Account info |
 | GET | `/api/v1/validators` | Validator list |
+| any | other `/api/...` | Returns `404 { "error": "API route not found" }` |
 
 ## Development
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -34,6 +34,18 @@ app.use('/api', require('./routes/transactions')(CHAIN_MODE, fetchRpc));
 app.use('/api', require('./routes/accounts')(CHAIN_MODE, fetchRpc));
 app.use('/api', require('./routes/validators')(CHAIN_MODE, fetchRpc));
 
+// 404 handler for API routes
+app.use('/api', (req, res) => {
+  res.status(404).json({ error: 'API route not found' });
+});
+
+// Generic error handler
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal server error' });
+});
+
 app.listen(PORT, () => {
   console.log(`Trident Network API server running on port ${PORT} in ${CHAIN_MODE} mode`);
 });

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,6 +26,18 @@ Available variables (defaults shown):
 - `REACT_APP_DEFAULT_LANGUAGE` (`en`) - initial UI language.
 - `REACT_APP_DEFAULT_THEME` (`dark`) - initial theme mode.
 
+## Quickstart
+
+Install dependencies and run the development server:
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The app will be available at `http://localhost:3000`.
+
 ### Multi-language Support
 
 The interface uses `react-i18next` with English and Portuguese translations built-in.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -48,6 +48,15 @@ body {
   margin-left: 0.5rem;
 }
 
+a {
+  color: var(--text-color);
+  text-decoration: none;
+}
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
 button {
   background: transparent;
   color: var(--text-color);

--- a/frontend/src/components/AccountLookup.js
+++ b/frontend/src/components/AccountLookup.js
@@ -45,7 +45,7 @@ function AccountLookup() {
     <div>
       <h2>{t('Account Lookup')}</h2>
       <input value={address} onChange={e => setAddress(e.target.value)} placeholder={t('Address')} />
-      <button onClick={lookup} className="ml-sm">{t('Lookup')}</button>
+      <button onClick={lookup} className="ml-sm" disabled={!address.trim()}>{t('Lookup')}</button>
       {loading && <Spinner />}
       {error && !loading && <p>{t('Service unavailable')}</p>}
       {account && !loading && !error && (

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -42,7 +42,7 @@ function NavBar({ wallet, logout, language, setLanguage, theme, toggleTheme }) {
           autoFocus
         />
       </form>
-      <button onClick={handleSearch} className="ml-sm">{t('Search')}</button>
+      <button onClick={handleSearch} className="ml-sm" disabled={!search.trim()}>{t('Search')}</button>
       <select value={language} onChange={e => setLanguage(e.target.value)} className="ml-sm">
         <option value="en">EN</option>
         <option value="pt">PT</option>


### PR DESCRIPTION
## Summary
- add docker compose quickstart steps
- document backend quickstart and API 404 behavior
- style link hover states
- disable account lookup & search buttons when empty
- handle backend 404 & generic errors

## Testing
- `npm run build` in frontend
- `node server.js` then curl `/api/v1/health` and `/api/v1/nothere`


------
https://chatgpt.com/codex/tasks/task_e_68779fdb8bc48328818c669df7148c65