### PR TITLE
Set Trident explorer for testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - Consolidated project documentation into a single README with unified environment variable reference and CI/CD overview.
+- Explorer configured for Trident Testnet only with testnet RPC defaults.
 
 
 ## [1.0.0] - 2024-06-01

--- a/README.md
+++ b/README.md
@@ -2,17 +2,26 @@
 
 A web explorer for the community-run Trident blockchain. The project provides a React frontend and an Express API server for inspecting blocks, transactions and accounts.
 
+**Note:** this explorer operates against the Trident Testnet only.
+
 ## Blockchain Specs
 
 - **Chain ID:** `0x76a81b116bfaa26e`
 - **Block Time:** 2 seconds
 - **Consensus:** Modified BFT Proof-of-Stake
 
+## Testnet Details
+
+- **RPC Endpoint:** `https://testnet.rpc.trident.network`
+- **Explorer API:** `https://testnet-explorer-api.trident.network`
+- **Example Addresses:** `TACC1PLACEHOLDER000000000000000000000`, `TACC2PLACEHOLDER000000000000000000000`
+- **Validators:** `TVAL1PLACEHOLDER000000000000000000000`, `TVAL2PLACEHOLDER000000000000000000000`
+
 ## Wallet Disclaimer
 
-The explorer includes a simple in-browser wallet. It is for demonstration only. **Do not use real private keys.**
+This explorer is connected to the **Trident Testnet only**. Do not use real assets or private keys.
 
-- `CHAIN_MODE=mock` – backend serves mock data and no real signing occurs.
+- `CHAIN_MODE=mock` – backend serves mock data and no real signing occurs (development only).
 - `CHAIN_MODE=rpc` – backend connects to a full node via `TRIDENT_NODE_RPC_URL`.
 
 Keys remain in browser memory and are cleared when the page reloads.
@@ -25,14 +34,14 @@ Copy `frontend/.env.example` and `backend/.env.example` to create `.env` files. 
 | ------------------- | ------- | ----------- |
 | `PORT` (frontend) | `3000` | Port for the React dev server |
 | `PORT` (backend) | `4000` | Port for the API server |
-| `REACT_APP_BACKEND_URL` | `http://localhost:4000` | API base URL used by the frontend |
+| `REACT_APP_BACKEND_URL` | `https://testnet-explorer-api.trident.network` | API base URL used by the frontend |
 | `REACT_APP_APP_TITLE` | `Trident Explorer` | Browser title and branding |
 | `REACT_APP_THEME_COLOR` | `#001730` | Primary UI color |
 | `REACT_APP_DEFAULT_LANGUAGE` | `en` | Initial language |
 | `REACT_APP_DEFAULT_THEME` | `dark` | Initial theme (light or dark) |
 | `REACT_APP_REFRESH_INTERVAL` | `10000` | Polling interval in ms for latest block |
-| `CHAIN_MODE` | `mock` | `mock` serves local data, `rpc` forwards requests |
-| `TRIDENT_NODE_RPC_URL` | `http://localhost:8090` | Node RPC endpoint when `CHAIN_MODE=rpc` |
+| `CHAIN_MODE` | `rpc` | `mock` serves local data, `rpc` forwards requests |
+| `TRIDENT_NODE_RPC_URL` | `https://testnet.rpc.trident.network` | Node RPC endpoint when `CHAIN_MODE=rpc` |
 | `FRONTEND_URL` | `http://localhost:3000` | Allowed CORS origin for the API |
 
 `REACT_APP_*` variables are baked into the frontend at build time. Rebuild the image or run the dev server again after changing them.
@@ -45,7 +54,7 @@ Copy `frontend/.env.example` and `backend/.env.example` to create `.env` files. 
 docker compose -f docker-compose.dev.yml up
 ```
 
-The command above starts the backend on port 4000 and the React app on port 3000 using mock data.
+The command above starts the backend on port 4000 and the React app on port 3000 with `CHAIN_MODE=mock` for local development.
 
 ### Production
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
 PORT=4000
-CHAIN_MODE=mock
-TRIDENT_NODE_RPC_URL=
+CHAIN_MODE=rpc
+TRIDENT_NODE_RPC_URL=https://testnet.rpc.trident.network
 FRONTEND_URL=http://localhost:3000

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon server.js",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "test": "jest"
+    "test": "CHAIN_MODE=mock jest"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,9 +6,15 @@ const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 4000;
-const CHAIN_MODE = process.env.CHAIN_MODE || 'mock';
+const CHAIN_MODE = process.env.CHAIN_MODE;
 const TRIDENT_NODE_RPC_URL = process.env.TRIDENT_NODE_RPC_URL || '';
 const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
+
+const validModes = ['mock', 'rpc'];
+if (!CHAIN_MODE || !validModes.includes(CHAIN_MODE)) {
+  console.error('CHAIN_MODE must be set to rpc for production deployments.');
+  process.exit(1);
+}
 
 app.use(helmet());
 const allowedOrigins = FRONTEND_URL ? FRONTEND_URL.split(',') : [];

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,9 @@ services:
     build: ./backend
     env_file:
       - ./backend/.env
+    environment:
+      - CHAIN_MODE=rpc
+      - TRIDENT_NODE_RPC_URL=https://testnet.rpc.trident.network
     ports:
       - "4000:4000"
 
@@ -11,11 +14,11 @@ services:
     build:
       context: ./frontend
       args:
-        REACT_APP_BACKEND_URL: ${REACT_APP_BACKEND_URL}
+        REACT_APP_BACKEND_URL: https://testnet-explorer-api.trident.network
     env_file:
       - ./frontend/.env
     environment:
-      - REACT_APP_BACKEND_URL=${REACT_APP_BACKEND_URL}
+      - REACT_APP_BACKEND_URL=https://testnet-explorer-api.trident.network
     ports:
       - "80:80"
     depends_on:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,5 @@
 PORT=3000
-REACT_APP_BACKEND_URL=http://localhost:4000
+REACT_APP_BACKEND_URL=https://testnet-explorer-api.trident.network
 REACT_APP_APP_TITLE=Trident Explorer
 REACT_APP_THEME_COLOR=#001730
 REACT_APP_DEFAULT_LANGUAGE=en

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -94,6 +94,12 @@ td {
   padding: 1rem;
 }
 
+.warning {
+  color: #ff9800;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
 .spinner {
   border: 4px solid rgba(255, 255, 255, 0.3);
   border-top: 4px solid var(--text-color);

--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -1,10 +1,13 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import LatestBlock from './LatestBlock';
 import BlockHistory from './BlockHistory';
 
 function Home() {
+  const { t } = useTranslation();
   return (
     <div className="container">
+      <p className="warning">{t('This explorer is connected to a testnet. Do not use real assets.')}</p>
       <LatestBlock />
       <BlockHistory />
     </div>

--- a/frontend/src/components/WalletPage.js
+++ b/frontend/src/components/WalletPage.js
@@ -47,6 +47,7 @@ function WalletPage({ wallet, login, logout }) {
     return (
       <div className="container">
       <h2>{t('Wallet Login')}</h2>
+      <p className="warning">{t('This explorer is connected to a testnet. Do not use real assets.')}</p>
       <p className="warning">{t('Use test accounts only. Keys stay in browser memory.')}</p>
         <input
           type="password"
@@ -62,6 +63,7 @@ function WalletPage({ wallet, login, logout }) {
   return (
     <div className="container">
       <h2>{t('Wallet Page')}</h2>
+      <p className="warning">{t('This explorer is connected to a testnet. Do not use real assets.')}</p>
       <p>{t('Address')}: {wallet.address} <CopyButton value={wallet.address} /></p>
       <button onClick={logout}>{t('Logout')}</button>
       {loading ? (

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -47,7 +47,8 @@ const resources = {
       "Copy": "Copy",
       "Not Found": "Not Found",
       "The requested page could not be found.": "The requested page could not be found.",
-      "Use test accounts only. Keys stay in browser memory.": "Use test accounts only. Keys stay in browser memory."
+      "Use test accounts only. Keys stay in browser memory.": "Use test accounts only. Keys stay in browser memory.",
+      "This explorer is connected to a testnet. Do not use real assets.": "This explorer is connected to a testnet. Do not use real assets."
     }
   },
   pt: {
@@ -94,7 +95,8 @@ const resources = {
       "Copy": "Copiar",
       "Not Found": "Não Encontrado",
       "The requested page could not be found.": "A página solicitada não foi encontrada.",
-      "Use test accounts only. Keys stay in browser memory.": "Use apenas contas de teste. Chaves ficam somente na memória do navegador."
+      "Use test accounts only. Keys stay in browser memory.": "Use apenas contas de teste. Chaves ficam somente na memória do navegador.",
+      "This explorer is connected to a testnet. Do not use real assets.": "Este explorador está conectado a uma testnet. Não use ativos reais."
     }
   },
   es: {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -40,5 +40,6 @@
   "of": "de",
   "Not Found": "No Encontrado",
   "The requested page could not be found.": "La página solicitada no fue encontrada.",
-  "Copy": "Copiar"
+  "Copy": "Copiar",
+  "This explorer is connected to a testnet. Do not use real assets.": "Este explorador está conectado a una testnet. No uses activos reales."
 }

--- a/kubernetes/trident-deployment.yml
+++ b/kubernetes/trident-deployment.yml
@@ -17,6 +17,13 @@ spec:
       containers:
       - name: trident-node
         image: trident-network:latest
+        env:
+        - name: CHAIN_MODE
+          value: "rpc"
+        - name: TRIDENT_NODE_RPC_URL
+          value: "https://testnet.rpc.trident.network"
+        - name: REACT_APP_BACKEND_URL
+          value: "https://testnet-explorer-api.trident.network"
         ports:
         - containerPort: 8090
         - containerPort: 50051


### PR DESCRIPTION
## Summary
- default to rpc mode and point env files to Trident testnet
- warn users to avoid real assets on the homepage and wallet pages
- validate CHAIN_MODE in the backend
- update Docker and Kubernetes manifests for testnet values
- document testnet details and usage in README
- note testnet configuration in changelog

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6878cfaeb38c8328bcc9416058407e51